### PR TITLE
added ''--no-sandbox" parameter to puppeteer.launch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ async function Main() {
             headless: appconfig.appconfig.headless,
             userDataDir: path.join(process.cwd(), "ChromeSession"),
             devtools: false,
-            args: [...constants.DEFAULT_CHROMIUM_ARGS, ...pptrArgv], ...extraArguments
+            args: ['--no-sanbox',...constants.DEFAULT_CHROMIUM_ARGS, ...pptrArgv], ...extraArguments
         });
         spinner.stop("Launching Chrome ... done!");
         if (argv.proxyURI) {


### PR DESCRIPTION
It was earlier failing the build in Linux.
reference:
https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix