### PR TITLE
do not activate webhook by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Run the command -
 chmod +x wbot-linux && wbot-linux
 ```
 
+Note: on Linux you need a running display server (X11 or Wayland).
+If you run Linux on a headless server or wan't to run chmomium without visible display try ```xvfb-run wbot-linux```.
+
 *I haven't tested Mac and Linux binaries. If you find any issues using them feel free to raise one from [here](https://github.com/vasani-arpit/WBOT/issues/new)*
 
 ### Configurations 
@@ -113,6 +116,22 @@ An object which contains suggestions and it's configs.
 here is how that looks
 
 ![smart reply gif](https://user-images.githubusercontent.com/6497827/58412366-f1653380-8093-11e9-8427-1ca19235faed.gif)
+
+
+## Run the latest code from github
+
+**This is only recommended for advanced 'node.js' users.**
+
+open a Terminal and create a new directory in your home directory, e.g. 'node' and goto there.
+Now download and run the latest code from github by:
+
+```
+git clone https://github.com/vasani-arpit/WBOT.git
+cd WBOT
+node src/index.js
+```
+
+If you run Linux on a headless server or wan't to run chmomium without visible display try ```xvfb-run wbot-linux```.
 
 
 ## 💻 Technologies

--- a/bot.json
+++ b/bot.json
@@ -2,6 +2,7 @@
     "appconfig": {
         "headless": false,
         "isGroupReply":false,
+        "webapi":false,
         "webhook":"https://lazy-cow-87.localtunnel.me/api/messages"
     },
     "bot": [{

--- a/bot.json
+++ b/bot.json
@@ -6,9 +6,10 @@
         "webhook":"https://lazy-cow-87.localtunnel.me/api/messages"
     },
     "bot": [{
-            "contains": [],
-            "exact": ["hi"],
-            "response": "hello"
+            "contains": ["amzn.to"],
+            "exact": [""],
+            "response": "",
+            "command": "echo"
         },
         {
             "contains": [],

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ var argv = require('yargs').argv;
 var rev = require("./detectRev");
 var constants = require("./constants");
 var configs = require("../bot");
+var child = require('child_process');
 
 //console.log(ps);
 
@@ -29,10 +30,14 @@ async function Main() {
         }
         console.log("WBOT is ready !! Let those message come.");
     } catch (e) {
-        console.error("Looks like you got an error." + e);
-        page.screenshot({ path: path.join(process.cwd(), "error.png") })
+        console.error("\nLooks like you got an error. " + e);
+        try {
+            page.screenshot({ path: path.join(process.cwd(), "error.png") })
+        } catch (s) {
+            console.error("Can't create shreenshot, X11 not running?. " + s);
+        }
         console.warn(e);
-        console.error("Don't worry errors are good. They help us improve. A screenshot has already been saved as error.png in current directory. Please mail it on vasani.arpit@gmail.com along with the steps to reproduce it.");
+        console.error("Don't worry errors are good. They help us improve. A screenshot has already been saved as error.png in current directory. Please mail it on vasani.arpit@gmail.com along with the steps to reproduce it.\n");
         throw e;
     }
 
@@ -140,8 +145,9 @@ async function Main() {
     async function getAndShowQR() {
         //TODO: avoid using delay and make it in a way that it would react to the event. 
         //await utils.delay(10000);
-        await page.waitForSelector("img[alt='Scan me!']");
-        var imageData = await page.evaluate(`document.querySelector("img[alt='Scan me!']").parentElement.getAttribute("data-ref")`);
+        var scanme = "img[alt='Scan me!'], canvas";
+        await page.waitForSelector(scanme);
+        var imageData = await page.evaluate(`document.querySelector("${scanme}").parentElement.getAttribute("data-ref")`);
         //console.log(imageData);
         qrcode.generate(imageData, { small: true });
         spinner.start("Waiting for scan \nKeep in mind that it will expire after few seconds");

--- a/src/inject.js
+++ b/src/inject.js
@@ -2,34 +2,36 @@ WAPI.waitNewMessages(false, (data) => {
     console.log(data)
     data.forEach((message) => {
         //fetch API to send and receive response from server
-        body = {};
-        body.text = message.body;
-        body.type = 'message';
-        body.user = message.from._serialized;
-        //body.original = message;
-        fetch(intents.appconfig.webhook, {
-            method: "POST",
-            body: JSON.stringify(body),
-            headers: {
-                'Content-Type': 'application/json'
-            }
-        }).then((resp) => resp.json()).then(function (response) {
-            //response received from server
-            console.log(response);
-            WAPI.sendSeen(message.from._serialized);
-            //replying to the user based on response
-            WAPI.sendMessage2(message.from._serialized, response[0].text);
-            //sending files if there is any 
-            if(response.files){
-                if (response.files.length > 0) {
-                    response.files.forEach((file) => {
-                        WAPI.sendImage(file.file, response.From, file.name);
-                    })
+        if(intents.appconfig.webapi != undefined && intents.appconfig.webapi) {
+            body = {};
+            body.text = message.body;
+            body.type = 'message';
+            body.user = message.from._serialized;
+            //body.original = message;
+            fetch(intents.appconfig.webhook, {
+                method: "POST",
+                body: JSON.stringify(body),
+                headers: {
+                    'Content-Type': 'application/json'
                 }
-            }
-        }).catch(function (error) {
-            console.log(error);
-        });
+            }).then((resp) => resp.json()).then(function (response) {
+                //response received from server
+                console.log(response);
+                WAPI.sendSeen(message.from._serialized);
+                //replying to the user based on response
+                WAPI.sendMessage2(message.from._serialized, response[0].text);
+                //sending files if there is any 
+                if(response.files){
+                    if (response.files.length > 0) {
+                        response.files.forEach((file) => {
+                            WAPI.sendImage(file.file, response.From, file.name);
+                        })
+                    }
+                }
+            }).catch(function (error) {
+                console.log(error);
+            });
+        }
         window.log(`Message from ${message.from.user} checking..`);
         if (intents.blocked.indexOf(message.from.user) >= 0) {
             window.log("number is blocked by BOT. no reply");


### PR DESCRIPTION
Webhook query is done by default and in your default config all messages are sent to ```https://lazy-cow-87.localtunnel.me/api/messages``` .

Send all messages by default to a unknown remote service is at best a privacy risc.

Even the user knows and removes the adress, an webapi query is done and an error is thrown.

So I implemented the switch ```webapi``` with a default value of ```false```. The webhook URL can stay, but the query is disabled by default. 