### PR TITLE
Automate tagging and releasing using GitHub actions

### DIFF
--- a/.github/build/Dockerfile
+++ b/.github/build/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:10.19.0-alpine3.10
+
+RUN apk add bash zip
+
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/*.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/.github/build/entrypoint.sh
+++ b/.github/build/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -x
+
+npm install
+npm run pack
+
+zip "WBOT-linux.zip"  bot.json github.png wbot-linux
+zip "WBOT-mac.zip"  bot.json github.png wbot-macos
+zip "WBOT-win.zip"  bot.json github.png wbot-win.exe

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -8,12 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: Get tag from package.json
+      id: get-tag
+      run: |
+        sudo apt update
+        sudo apt install -y jq
+        echo ::set-output name=tag::$(cat package.json | jq -r .version)
     - name: Bump version and push tag
       id: create_tag
       uses: anothrNick/github-tag-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
+        CUSTOM_TAG: v${{ steps.get-tag.outputs.tag }}
     - name: Build project
       uses: ./.github/build
       env:

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -1,0 +1,57 @@
+name: Tag and Release
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Bump version and push tag
+      id: create_tag
+      uses: anothrNick/github-tag-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+    - name: Build project
+      uses: ./.github/build
+      env:
+        NEW_TAG: ${{ steps.create_tag.outputs.new_tag }}
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.create_tag.outputs.new_tag }}
+        release_name: Release ${{ steps.create_tag.outputs.new_tag }}
+        draft: false
+        prerelease: false
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./WBOT-linux.zip
+        asset_name: WBOT-linux.zip
+        asset_content_type: application/zip
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./WBOT-mac.zip
+        asset_name: WBOT-mac.zip
+        asset_content_type: application/zip
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./WBOT-win.zip
+        asset_name: WBOT-win.zip
+        asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 macOS | Windows | Linux
 -----------------| ---| ---|
-[Download v0.11-beta](https://github.com/vasani-arpit/WBOT/releases/download/0.11/WBOT-mac-0.11.zip) | [Download v0.11-beta](https://github.com/vasani-arpit/WBOT/releases/download/0.11/WBOT-win-0.11.zip) | [Download v0.11-beta](https://github.com/vasani-arpit/WBOT/releases/download/0.11/WBOT-linux-0.11.zip)
+[Download Latest Release](https://github.com/vasani-arpit/WBOT/releases/latest/download/WBOT-mac.zip) | [Download Latest Release](https://github.com/vasani-arpit/WBOT/releases/latest/download/WBOT-win.zip) | [Download Latest Release](https://github.com/vasani-arpit/WBOT/releases/latest/download/WBOT-linux.zip)
 
 
 ## Supported Platforms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wbot",
-  "version": "0.9.0",
+  "version": "0.12.0",
   "description": "A simple whatsapp reply bot using puppeteer.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
1. Added GitHub actions to create tag, build binaries and then create a release from the pushed tag with attached binaries as artifacts in the release.

2. By default, the actions are setup to get the tag versions from package.json file.

3. Updated readme to always point to the latest released artifact so that update in the readme is not required after every release.