### PR TITLE
clicktosend: Send the message instantly. (0.23.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wbot",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wbot",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "A simple whatsapp reply bot using puppeteer.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -201,10 +201,10 @@ async function Main() {
         page.waitForSelector("#main", { timeout: 0 }).then(async () => {
             await page.exposeFunction("sendMessage", async message => {
                 return new Promise(async (resolve, reject) => {
-                    //send message to the currently open chat using power of puppeteer 
-                    await page.type("#main div.selectable-text[data-tab]", message);
+                    // Type message with space to the currently open chat using power of puppeteer 
+                    await page.type("#main div.selectable-text[data-tab]", message + " ");
                     if (configs.smartreply.clicktosend) {
-                        await page.click("#main footer div.copyable-area div div div button");
+                        page.keyboard.press("Enter");
                     }
                 });
             });


### PR DESCRIPTION
**(Bumped version: 0.23.0)**


**BUG**: `clicktosend` feature does not work. Fixes #270 

**Solution**: Replace `await page.click("#main footer div.copyable-area div div div button");` with `page.keyboard.press("Enter");`

**Testing plan**: Tested with `clicktosend` true and false value

**GIF**:
![clicktosend](https://user-images.githubusercontent.com/59444243/138637709-dfead444-4a34-45ed-b27d-a0ff3b256ecf.gif)
