### PR TITLE
Refractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wbot",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wbot",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "A simple whatsapp reply bot using puppeteer.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
**Bumped version: 0.25.0**

The older behavior of the codebase doesn't send the file response when we have file and have not defined `responseAsCaption`.
The good behavior is to send the response in all condition (even when `responseAsCaption` is undefined)

This PR fixes the above issue as well as refractor some code which is also a TODO (as mentioned in the codebase)

**Testing plan:** Tested it with all 3 combinations of `responseAsCaption` (i.e true, false, undefined)
(Also tested with other combinations like only response for exact or partialMatch or noMatch)